### PR TITLE
v0.1.3

### DIFF
--- a/lib/fxnk/Math.ex
+++ b/lib/fxnk/Math.ex
@@ -2,7 +2,6 @@ defmodule Fxnk.Math do
   @moduledoc """
   `Fxnk.Math` are functions dealing with math.
   """
-  import Fxnk.Functions, only: [curry: 1]
 
   @doc """
   Find the maximum of a list.
@@ -63,7 +62,7 @@ defmodule Fxnk.Math do
   """
   @spec add(number) :: function()
   def add(n) when is_number(n) do
-    curry(fn arg -> arg + n end)
+    fn arg -> arg + n end
   end
 
   @doc """
@@ -88,7 +87,7 @@ defmodule Fxnk.Math do
   """
   @spec subtract(number()) :: function()
   def subtract(n) when is_number(n) do
-    curry(fn arg -> arg - n end)
+    fn arg -> arg - n end
   end
 
   @doc """
@@ -115,7 +114,7 @@ defmodule Fxnk.Math do
   """
   @spec divide(number()) :: function()
   def divide(n) when is_number(n) do
-    curry(fn arg -> n / arg end)
+    fn arg -> n / arg end
   end
 
   @doc """
@@ -142,7 +141,7 @@ defmodule Fxnk.Math do
   """
   @spec multiply(number()) :: function()
   def multiply(n) when is_number(n) do
-    curry(fn arg -> n * arg end)
+    fn arg -> n * arg end
   end
 
   @doc """
@@ -210,7 +209,7 @@ defmodule Fxnk.Math do
   """
   @spec clamp(integer(), integer()) :: fun
   def clamp(from, to) do
-    curry(fn n -> clamp(n, from, to) end)
+    fn n -> clamp(n, from, to) end
   end
 
   @doc """

--- a/lib/fxnk/Math.ex
+++ b/lib/fxnk/Math.ex
@@ -60,7 +60,7 @@ defmodule Fxnk.Math do
       iex> addOne.(2)
       3
   """
-  @spec add(number) :: function()
+  @spec add(number) :: (number() -> number())
   def add(n) when is_number(n) do
     fn arg -> arg + n end
   end
@@ -85,7 +85,7 @@ defmodule Fxnk.Math do
       iex> minusOne.(5)
       4
   """
-  @spec subtract(number()) :: function()
+  @spec subtract(number()) :: (number() -> number())
   def subtract(n) when is_number(n) do
     fn arg -> arg - n end
   end
@@ -112,7 +112,7 @@ defmodule Fxnk.Math do
       iex> recip.(4)
       0.25
   """
-  @spec divide(number()) :: function()
+  @spec divide(number()) :: (number() -> float())
   def divide(n) when is_number(n) do
     fn arg -> n / arg end
   end
@@ -139,7 +139,7 @@ defmodule Fxnk.Math do
       iex> timesTen.(10)
       100
   """
-  @spec multiply(number()) :: function()
+  @spec multiply(number()) :: (number() -> number())
   def multiply(n) when is_number(n) do
     fn arg -> n * arg end
   end

--- a/lib/fxnk/Math.ex
+++ b/lib/fxnk/Math.ex
@@ -207,7 +207,7 @@ defmodule Fxnk.Math do
       iex> between1And10.(15)
       10
   """
-  @spec clamp(integer(), integer()) :: fun
+  @spec clamp(integer(), integer()) :: (integer() -> number())
   def clamp(from, to) do
     fn n -> clamp(n, from, to) end
   end
@@ -223,7 +223,7 @@ defmodule Fxnk.Math do
       iex> Fxnk.Math.clamp(17, 15, 20)
       17
   """
-  @spec clamp(integer(), integer(), integer()) :: integer()
+  @spec clamp(integer(), integer(), integer()) :: number()
   def clamp(n, from, to) do
     cond do
       n <= from -> from

--- a/lib/fxnk/flow.ex
+++ b/lib/fxnk/flow.ex
@@ -2,7 +2,6 @@ defmodule Fxnk.Flow do
   @moduledoc """
   `Fxnk.Flow` functions are used for control flow.
   """
-  import Fxnk.Functions, only: [curry: 1]
   import Fxnk.List, only: [reduce_right: 3]
 
   @doc """
@@ -15,7 +14,7 @@ defmodule Fxnk.Flow do
   """
   @spec compose([function(), ...]) :: (any() -> any())
   def compose(fns) when is_list(fns) do
-    curry(fn arg -> compose(arg, fns) end)
+    fn arg -> compose(arg, fns) end
   end
 
   @doc """
@@ -43,7 +42,7 @@ defmodule Fxnk.Flow do
   """
   @spec if_else(function(), function(), function()) :: (any() -> any())
   def if_else(pred, passFunc, failFunc) do
-    curry(fn input -> if_else(input, pred, passFunc, failFunc) end)
+    fn input -> if_else(input, pred, passFunc, failFunc) end
   end
 
   @doc """
@@ -74,7 +73,7 @@ defmodule Fxnk.Flow do
   """
   @spec pipe([function(), ...]) :: (any() -> any())
   def pipe(fns) when is_list(fns) do
-    curry(fn arg -> pipe(arg, fns) end)
+    fn arg -> pipe(arg, fns) end
   end
 
   @doc """
@@ -102,7 +101,7 @@ defmodule Fxnk.Flow do
   """
   @spec unless_is(function(), function()) :: (any() -> any())
   def unless_is(pred, func) do
-    curry(fn input -> unless_is(input, pred, func) end)
+    fn input -> unless_is(input, pred, func) end
   end
 
   @doc """
@@ -133,7 +132,7 @@ defmodule Fxnk.Flow do
   """
   @spec until(function(), function()) :: (any() -> any())
   def until(pred, func) do
-    curry(fn init -> until(init, pred, func) end)
+    fn init -> until(init, pred, func) end
   end
 
   @doc """
@@ -164,7 +163,7 @@ defmodule Fxnk.Flow do
   """
   @spec when_is(function(), function()) :: (any() -> any())
   def when_is(pred, func) do
-    curry(fn input -> when_is(input, pred, func) end)
+    fn input -> when_is(input, pred, func) end
   end
 
   @doc """

--- a/lib/fxnk/functions.ex
+++ b/lib/fxnk/functions.ex
@@ -59,7 +59,7 @@ defmodule Fxnk.Functions do
   """
   @spec converge(function(), [function(), ...]) :: (any() -> any())
   def converge(to_fn, fns) do
-    curry(fn args -> converge(args, to_fn, fns) end)
+    fn args -> converge(args, to_fn, fns) end
   end
 
   @doc """
@@ -136,7 +136,7 @@ defmodule Fxnk.Functions do
   """
   @spec juxt([function(), ...]) :: (any() -> any())
   def juxt(fns) when is_list(fns) do
-    curry(fn arg -> juxt(arg, fns) end)
+    fn arg -> juxt(arg, fns) end
   end
 
   @doc """
@@ -173,7 +173,7 @@ defmodule Fxnk.Functions do
   """
   @spec tap(function()) :: (any() -> any())
   def tap(func) do
-    curry(fn val -> tap(val, func) end)
+    fn val -> tap(val, func) end
   end
 
   @doc """

--- a/lib/fxnk/logic.ex
+++ b/lib/fxnk/logic.ex
@@ -2,7 +2,6 @@ defmodule Fxnk.Logic do
   @moduledoc """
   `Fxnk.Logic` are functions for dealing with booleans.
   """
-  import Fxnk.Functions, only: [curry: 1]
 
   @doc """
   Curried `and?/2`.
@@ -16,7 +15,7 @@ defmodule Fxnk.Logic do
   """
   @spec and?(any) :: (any() -> boolean())
   def and?(x) do
-    curry(fn y -> and?(x, y) end)
+    fn y -> and?(x, y) end
   end
 
   @doc """
@@ -44,7 +43,7 @@ defmodule Fxnk.Logic do
   """
   @spec both?(function(), function()) :: (any() -> boolean())
   def both?(func1, func2) do
-    curry(fn input -> both?(input, func1, func2) end)
+    fn input -> both?(input, func1, func2) end
   end
 
   @doc """
@@ -87,7 +86,7 @@ defmodule Fxnk.Logic do
       "thanks for all the fish"
   """
   @spec default_to(any()) :: (any() -> boolean())
-  def default_to(x), do: curry(fn y -> default_to(y, x) end)
+  def default_to(x), do: fn y -> default_to(y, x) end
 
   @doc """
   `default_to/2` takes two values and returns the right side value if the left side is `false` or `nil`
@@ -121,7 +120,7 @@ defmodule Fxnk.Logic do
   """
   @spec either?(function(), function()) :: (any() -> boolean())
   def either?(func1, func2) do
-    curry(fn input -> either?(input, func1, func2) end)
+    fn input -> either?(input, func1, func2) end
   end
 
   @doc """
@@ -165,7 +164,7 @@ defmodule Fxnk.Logic do
       true
   """
   @spec is_not?(any) :: (any() -> boolean())
-  def is_not?(x), do: curry(fn y -> is_not?(x, y) end)
+  def is_not?(x), do: fn y -> is_not?(x, y) end
 
   @doc """
   `is_not/3` returns true if both inputs are not the same, opposite of `and?/2`
@@ -190,7 +189,7 @@ defmodule Fxnk.Logic do
 
   """
   @spec or?(any) :: (boolean() -> boolean())
-  def or?(x), do: curry(fn y -> or?(x, y) end)
+  def or?(x), do: fn y -> or?(x, y) end
 
   @doc """
   `or/2` returns true if one or both of its arguments are true.
@@ -220,7 +219,7 @@ defmodule Fxnk.Logic do
   """
   @spec gt?(number) :: (number -> boolean())
   def gt?(x) do
-    curry(fn y -> x < y end)
+    fn y -> x < y end
   end
 
   @doc """
@@ -235,7 +234,7 @@ defmodule Fxnk.Logic do
   """
   @spec lt?(number) :: (number -> boolean())
   def lt?(x) do
-    curry(fn y -> x > y end)
+    fn y -> x > y end
   end
 
   @doc """

--- a/lib/fxnk/map.ex
+++ b/lib/fxnk/map.ex
@@ -2,7 +2,6 @@ defmodule Fxnk.Map do
   @moduledoc """
   `Fxnk.Map` are functions that work with maps.
   """
-  import Fxnk.Functions, only: [curry: 1]
 
   @doc """
   Accepts a string `key` and returns a function that takes a `map`. Returns the map's value at `key` or `nil`.
@@ -17,7 +16,7 @@ defmodule Fxnk.Map do
   """
   @spec prop(atom() | binary()) :: (map() -> any())
   def prop(key) when is_binary(key) or is_atom(key) do
-    curry(fn map -> prop(map, key) end)
+    fn map -> prop(map, key) end
   end
 
   @doc """
@@ -47,7 +46,7 @@ defmodule Fxnk.Map do
   """
   @spec props([atom() | binary(), ...]) :: (map() -> [any(), ...])
   def props(keys) when is_list(keys) do
-    curry(fn map -> props(map, keys) end)
+    fn map -> props(map, keys) end
   end
 
   @doc """
@@ -74,7 +73,7 @@ defmodule Fxnk.Map do
   """
   @spec pick([atom(), ...]) :: (map() -> map())
   def pick(args) when is_list(args) do
-    curry(fn map -> pick(map, args) end)
+    fn map -> pick(map, args) end
   end
 
   @doc """
@@ -105,7 +104,7 @@ defmodule Fxnk.Map do
   """
   @spec has_prop?(atom() | String.t()) :: (map() -> boolean())
   def has_prop?(property) when is_binary(property) or is_atom(property) do
-    curry(fn map -> has_prop?(map, property) end)
+    fn map -> has_prop?(map, property) end
   end
 
   @doc """

--- a/lib/fxnk/map.ex
+++ b/lib/fxnk/map.ex
@@ -34,6 +34,45 @@ defmodule Fxnk.Map do
   end
 
   @doc """
+  Curried `prop_equals/3`, takes a value, returns a function that accepts a map and a key.
+
+  ## Examples
+      iex> isFoo = Fxnk.Map.prop_equals("foo")
+      iex> isFoo.(%{foo: "foo"}, :foo)
+  """
+  @spec prop_equals(any()) :: (map(), atom() | String.t() -> boolean())
+  def prop_equals(value) do
+    fn map, key -> prop_equals(map, key, value) end
+  end
+
+  @doc """
+  Curried `prop_equals/3`, takes a key and a value. Returns a function that accepts a map.
+
+  ## Examples
+      iex> isKeyFoo = Fxnk.Map.prop_equals(:foo, "foo")
+      iex> isKeyFoo.(%{foo: "foo"})
+      true
+  """
+  @spec prop_equals(atom | binary, any) :: (map() -> boolean())
+  def prop_equals(key, value) when is_atom(key) or is_binary(key) do
+    fn map -> prop_equals(map, key, value) end
+  end
+
+  @doc """
+  Accepts a map, key and value. Checks to see if the key on the map is equal to the value.any()
+
+  ## Examples
+    iex> Fxnk.Map.prop_equals(%{foo: "foo"}, :foo, "foo")
+    true
+    iex> Fxnk.Map.prop_equals(%{foo: "bar"}, :foo, "foo")
+    false
+  """
+  @spec prop_equals(map(), atom() | binary(), any()) :: boolean()
+  def prop_equals(map, key, value) when is_map(map) and (is_binary(key) or is_atom(key)) do
+    map[key] === value
+  end
+
+  @doc """
   Accepts a list of keys and returns a function that takes a map. Returns a list of the values associated with the keys in the map.
 
   ## Examples


### PR DESCRIPTION
- Fix more types
- Remove `curry` from all curried functions, turns out we don't need it.

- Add `prop_equals/1`, `prop_equals/2`, `prop_equals/3`